### PR TITLE
Add Circuit Playground Express

### DIFF
--- a/boards.json
+++ b/boards.json
@@ -12,6 +12,20 @@
 			}
 		]
 	},
+	"circuitplay-express": {
+		"name": "circuitplay-express",
+		"humanName": "Circuit Playground Express",
+		"example": "blinky1",
+		"firmwareFormat": "uf2",
+		"devices": [
+			{
+				"type": "led",
+				"name": "LED",
+				"color": "red",
+				"cathode": 17
+			}
+		]
+	},
 	"hifive1b": {
 		"name": "hifive1b",
 		"humanName": "HiFive1 rev B",

--- a/compiler.go
+++ b/compiler.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -116,7 +117,8 @@ func (job compilerJob) Run() error {
 	switch job.Format {
 	case "wasm":
 		// simulate
-		cmd = exec.Command("tinygo", "build", "-o", tmpfile, "-tags", job.Target, "-no-debug", infile.Name())
+		tag := strings.Replace(job.Target, "-", "_", -1) // '-' not allowed in tags, use '_' instead
+		cmd = exec.Command("tinygo", "build", "-o", tmpfile, "-tags", tag, "-no-debug", infile.Name())
 	default:
 		// build firmware
 		cmd = exec.Command("tinygo", "build", "-o", tmpfile, "-target", job.Target, "-no-debug", infile.Name())

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func handleCompile(w http.ResponseWriter, r *http.Request) {
 	case "", "wasm":
 		// Run code in the browser.
 		format = "wasm"
-	case "elf", "hex":
+	case "elf", "hex", "uf2":
 		// Build a firmware that can be flashed directly to a development board.
 	default:
 		// Unrecognized format. Disallow to be sure (might introduce security


### PR DESCRIPTION
Depends on https://github.com/tinygo-org/tinygo/pull/766.

I could flash the default blinking LED example to the board. Once the ws2812 driver is supported in the playground (I think I have some code for that already) we could make the demo more interesting.