### PR TITLE
site: serve up needed cross-domain header policies

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cross-Origin-Opener-Policy = "same-origin"
+    Cross-Origin-Embedder-Policy = "require-corp"


### PR DESCRIPTION
This PR adds the needed cross-domain policy headers using Netlify.